### PR TITLE
Recitation 3: Added suggested username to registration error message

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,9 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    console.log('repeated username');
+                    const suggestedUsername = username + '123';
+                    showError(username_notify, '[[error:username-taken]], Try using: ' + suggestedUsername);
                 }
 
                 callback();


### PR DESCRIPTION
Related Issue:
Resolves #1 

Changes Made:
Modified public/src/client/registration.js to display a suggested name along with the existing error message when the inputted username is already taken. The suggested username will be the provided one with the suffix '123'.

Applies to:
Username provided during registration

Testing:
Verified updated message displays during registration in local server
<img width="1458" height="922" alt="Screenshot 2025-09-15 at 10 04 37 AM" src="https://github.com/user-attachments/assets/759e08fd-0404-498c-90c4-f62d66185a0e" />
