### PR TITLE
Duplicate Username Error Message

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -36,7 +36,7 @@
 
 	"invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
 
-	"username-taken": "Username taken. Try [new username] instead",
+	"username-taken": "Username taken. Try username/suffix instead",
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -36,7 +36,7 @@
 
 	"invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
 
-	"username-taken": "Username taken",
+	"username-taken": "Username taken. Try [new username] instead",
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken. Try [new username] instead",
+    "username-taken": "Username taken. Try username/suffix instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Try [new username] instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/en-x-pirate/error.json
+++ b/public/language/en-x-pirate/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken. Try [new username] instead",
+    "username-taken": "Username taken. Try username/suffix instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/en-x-pirate/error.json
+++ b/public/language/en-x-pirate/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Try [new username] instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/sc/error.json
+++ b/public/language/sc/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken. Try [new username] instead",
+    "username-taken": "Username taken. Try username/suffix instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/sc/error.json
+++ b/public/language/sc/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Try [new username] instead",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",


### PR DESCRIPTION
Fixed the error message that was displayed when a user typed in a username that was already taken. This way, it'll suggest a new one. I edited the error.json file so that the text would change to username/suffix to suggest a new username.