### PR TITLE
feat: username taken change

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]] Maybe try ${username}suffix`);
                 }
 
                 callback();


### PR DESCRIPTION
I improved the error message to suggest a username with a suffix if the username is taken
<img width="1014" height="512" alt="Screenshot 2025-09-15 at 10 37 18 AM" src="https://github.com/user-attachments/assets/d6377250-fd07-458a-a8ee-e34799c8ff42" />
