### PR TITLE
Add username suggestion on error for taken usernames

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,9 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    // build new suggestion
+                    const suggestion = username + 'suffix';
+                    showError(username_notify, `[[error:username-taken]] Maybe try "${suggestion}"`);
                 }
 
                 callback();


### PR DESCRIPTION
This modifies public/src/client/forum/register.js under function validateUsername(username, callback).

It improves the user registration.

When a chosen username is already taken, instead of only showing the error message the code appends "suffix" to the entered username and suggests it as an alternative. This improves the user experience by giving users a clear next step instead of only showing the error message.

Before change:
<img width="1159" height="504" alt="image" src="https://github.com/user-attachments/assets/25310d69-0ad7-412d-8bf0-c2dfde182d37" />

After change:
<img width="1182" height="532" alt="image" src="https://github.com/user-attachments/assets/a6d1d1aa-958b-4956-917a-622f4bbce69f" />