### PR TITLE
Changed the error message generated for creating an account with existing username (Recitation 3)

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken, ${username}]]`);
                 }
 
                 callback();


### PR DESCRIPTION
Link to GitHub issue: https://github.com/CMU-313/NodeBB-F25-R3/issues/1

Changed the error message generated when a new account registration attempt is made with a username that already exists to include a suggested username (the original with a suffix).
