### PR TITLE
Recitation 3 - Altered username taken message to append a suffix

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]]. Maybe try "${username}123" `);
                 }
 
                 callback();


### PR DESCRIPTION
NodeBB now automatically suggests an alternative username when the chosen username is already in use. Per recitation instructions, It append a suffix string to the user's original choice.

Issue Solved: [Issue](https://github.com/CMU-313/NodeBB-F25-R3/issues/1)