### PR TITLE
Recitation 3: Changed username taken message to suggest with suffix on registration

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]] Try: ${username}123`);
                 }
 
                 callback();


### PR DESCRIPTION
Now, instead of just saying "Username Taken" when a user tries to register with a taken username on Nodebb, it shows a suggestion. Here, the suggestion is just the original username attempt with a static "123" added on the back. This only required modification of /public/src/client/register.js


Issue: https://github.com/CMU-313/NodeBB-F25-R3/issues/1
