### PR TITLE
Username suggestion on username taken registration error

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Try %1", 
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/pt-BR/error.json
+++ b/public/language/pt-BR/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Valor de paginação inválido, precisa ser no mínimo %1 e no máximo %2",
-    "username-taken": "Nome de usuário já existe",
+    "username-taken": "Nome de usuário já existe. Tente %1",
     "email-taken": "Email já cadastrado",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "O email já foi convidado",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, (`[[error:username-taken, "${username}123"]]`));
                 }
 
                 callback();


### PR DESCRIPTION
When registering into Nodebb, if you picked a taken username, it would only show you an error message saying "username taken". Now, the error message also includes a suggested username with a suffix of 123.

The following files were modified:

./public/language/en-US/error.json: line 34
./public/language/pt-BR/error.json: line 34
./public/src/client/register.js: line 134

No new issues were introduced.