### PR TITLE
added a suggestion for new username when username already taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken, "${username}suffix"]]`);
                 }
 
                 callback();


### PR DESCRIPTION
Link to issue #1 

When registering a new user to Nodebb, this change will suggest a suffix following the current username if the username the user is trying to register already exists.

File modified:
./public/src/client/register.js: line 134

