### PR TITLE
Recitation 3: Modification to suggest a new username if a username is taken during registration

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]]. Maybe try "${username}suffix"`);
                 }
 
                 callback();


### PR DESCRIPTION
Related issue:
Resolves #1 

Changes Made:
Modified public/src/client/registration.js to display suggested name along with suffix when username is already taken. 

Applies to:
Username provided during registration.

Testing:
Manually tested/verified updated message during registration with local server.
<img width="2538" height="1156" alt="image" src="https://github.com/user-attachments/assets/abca65c3-61c0-47c7-a0b3-7bb73066424d" />
