### PR TITLE
Suggest alternative username when chosen name is taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]. Maybe try "' + username + 'suffix"');
                 }
 
                 callback();


### PR DESCRIPTION
Closes #1 

When a user attempts to register with a username that is already taken, NodeBB previously displayed only the message “Username taken.”

With this change, the system now provides a suggested alternative by appending a suffix to the attempted username.

Proof:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6f5459ed-908d-4792-97a0-04c22535bd0a" />
