### PR TITLE
Recitation 3: changes made to register to suggest suffix

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,9 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    // showError(username_notify, '[[error:username-taken]]');
+                    const suggestion = username + 'suffix';
+                    showError(username_notify, `[[error:username-taken]] — try "${suggestion}" instead`);
                 }
 
                 callback();


### PR DESCRIPTION
Closes #1 

When a user register with a name that is already in the database, the previous message only displays 'this user name is taken',  with this change, the system will now display 'this user name is taken - try {username}suffix instead'.
<img width="1125" height="611" alt="image" src="https://github.com/user-attachments/assets/9dfd9719-d9c2-46d0-bc91-888f7ae6e126" />
