### PR TITLE
Fixed username taken error message

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",


### PR DESCRIPTION
Added an updated description to the "Username Taken" Error to include new suggestions for usernames, rather than just showing the issue. 