### PR TITLE
Recitation 3: Added suffix to username taken error

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suffix = username + 'suffix';
+                    showError(username_notify, `[[error:username-taken]]. Try ${suffix}`);
                 }
 
                 callback();


### PR DESCRIPTION
Resolves #1 

Changes:
Modified public/src/client/register.js to add 'suffix' to a taken username as a suggestion

Testing:
tested on admin username. Rather than 'username taken' it shows "try adminsuffix" instead.


<img width="1512" height="953" alt="Screenshot 2025-09-15 at 2 52 48 PM" src="https://github.com/user-attachments/assets/31885faf-fd8d-4719-8469-06b2b0bd89b1" />
