### PR TITLE
Recitation 3 - Username Error

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suggestion1 = `${username}suffix'
+                    showError(username_notify, 'Username taken. Maybe try "${suggestion1}"';
                 }
 
                 callback();


### PR DESCRIPTION
In register.js - I found the function validateUsername and the username-taken error they were initially using. I changed it to a string that said 'Username taken. Maybe try "${suggestion1}"', with suggestion1 being a constant variable with the user's attempted username + suffix.