### PR TITLE
Made changes to implement suggesting alternative usernames

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,11 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suggested = username + 'suffix';
+                    showError(
+                        username_notify,
+                        `[[error:username-taken]]. Maybe try "${suggested}"`
+                    );
                 }
 
                 callback();


### PR DESCRIPTION
When a user enters a username that is already taken, NodeBB should **suggest an alternative** instead of only showing “Username taken.” This PR appends a suffix to the original choice and displays the suggestion to the user.  
Example: user types `nihitha` → suggest `nihithasuffix`.

Resolved issue #1 
<img width="1229" height="561" alt="nodebb username check" src="https://github.com/user-attachments/assets/9dce1235-daa3-4cf1-8363-97dd138900cd" />
