### PR TITLE
Suggest username in error message if username taken during registration

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -3,19 +3,16 @@
 	"invalid-json": "Invalid JSON",
 	"wrong-parameter-type": "A value of type %3 was expected for property `%1`, but %2 was received instead",
 	"required-parameters-missing": "Required parameters were missing from this API call: %1",
-
 	"not-logged-in": "You don't seem to be logged in.",
 	"account-locked": "Your account has been locked temporarily",
 	"search-requires-login": "Searching requires an account - please login or register.",
 	"goback": "Press back to return to the previous page",
-
 	"invalid-cid": "Invalid Category ID",
 	"invalid-tid": "Invalid Topic ID",
 	"invalid-pid": "Invalid Post ID",
 	"invalid-uid": "Invalid User ID",
 	"invalid-mid": "Invalid Chat Message ID",
 	"invalid-date": "A valid date must be provided",
-
 	"invalid-username": "Invalid Username",
 	"invalid-email": "Invalid Email",
 	"invalid-fullname": "Invalid Fullname",
@@ -33,10 +30,8 @@
 	"csrf-invalid": "We were unable to log you in, likely due to an expired session. Please try again",
 	"invalid-path": "Invalid path",
 	"folder-exists": "Folder exists",
-
 	"invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-
-	"username-taken": "Username taken",
+	"username-taken": "Username taken. Maybe try \"%1suffix\"",
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",
@@ -49,20 +44,17 @@
 	"confirm-email-already-sent": "Confirmation email already sent, please wait %1 minute(s) to send another one.",
 	"sendmail-not-found": "The sendmail executable could not be found, please ensure it is installed and executable by the user running NodeBB.",
 	"digest-not-enabled": "This user does not have digests enabled, or the system default is not configured to send digests",
-
 	"username-too-short": "Username too short",
 	"username-too-long": "Username too long",
 	"password-too-long": "Password too long",
 	"reset-rate-limited": "Too many password reset requests (rate limited)",
 	"reset-same-password": "Please use a password that is different from your current one",
-
 	"user-banned": "User banned",
 	"user-banned-reason": "Sorry, this account has been banned (Reason: %1)",
 	"user-banned-reason-until": "Sorry, this account has been banned until %1 (Reason: %2)",
 	"user-too-new": "Sorry, you are required to wait %1 second(s) before making your first post",
 	"blacklisted-ip": "Sorry, your IP address has been banned from this community. If you feel this is in error, please contact an administrator.",
 	"ban-expiry-missing": "Please provide an end date for this ban",
-
 	"no-category": "Category does not exist",
 	"no-topic": "Topic does not exist",
 	"no-post": "Post does not exist",
@@ -71,9 +63,7 @@
 	"no-teaser": "Teaser does not exist",
 	"no-flag": "Flag does not exist",
 	"no-privileges": "You do not have enough privileges for this action.",
-
 	"category-disabled": "Category disabled",
-
 	"topic-locked": "Topic Locked",
 	"post-edit-duration-expired": "You are only allowed to edit posts for %1 second(s) after posting",
 	"post-edit-duration-expired-minutes": "You are only allowed to edit posts for %1 minute(s) after posting",
@@ -82,7 +72,6 @@
 	"post-edit-duration-expired-hours-minutes": "You are only allowed to edit posts for %1 hour(s) %2 minute(s) after posting",
 	"post-edit-duration-expired-days": "You are only allowed to edit posts for %1 day(s) after posting",
 	"post-edit-duration-expired-days-hours": "You are only allowed to edit posts for %1 day(s) %2 hour(s) after posting",
-
 	"post-delete-duration-expired": "You are only allowed to delete posts for %1 second(s) after posting",
 	"post-delete-duration-expired-minutes": "You are only allowed to delete posts for %1 minute(s) after posting",
 	"post-delete-duration-expired-minutes-seconds": "You are only allowed to delete posts for %1 minute(s) %2 second(s) after posting",
@@ -90,10 +79,8 @@
 	"post-delete-duration-expired-hours-minutes": "You are only allowed to delete posts for %1 hour(s) %2 minute(s) after posting",
 	"post-delete-duration-expired-days": "You are only allowed to delete posts for %1 day(s) after posting",
 	"post-delete-duration-expired-days-hours": "You are only allowed to delete posts for %1 day(s) %2 hour(s) after posting",
-
 	"cant-delete-topic-has-reply": "You can't delete your topic after it has a reply",
 	"cant-delete-topic-has-replies": "You can't delete your topic after it has %1 replies",
-
 	"content-too-short": "Please enter a longer post. Posts should contain at least %1 character(s).",
 	"content-too-long": "Please enter a shorter post. Posts can't be longer than %1 character(s).",
 	"title-too-short": "Please enter a longer title. Titles should contain at least %1 character(s).",
@@ -108,23 +95,19 @@
 	"too-many-tags": "Too many tags. Topics can't have more than %1 tag(s)",
 	"cant-use-system-tag": "You can not use this system tag.",
 	"cant-remove-system-tag": "You can not remove this system tag.",
-
 	"still-uploading": "Please wait for uploads to complete.",
 	"file-too-big": "Maximum allowed file size is %1 kB - please upload a smaller file",
 	"guest-upload-disabled": "Guest uploading has been disabled",
 	"cors-error": "Unable to upload image due to misconfigured CORS",
 	"upload-ratelimit-reached": "You have uploaded too many files at one time. Please try again later.",
-
-  	"scheduling-to-past": "Please select a date in the future.",
-  	"invalid-schedule-date": "Please enter a valid date and time.",
-  	"cant-pin-scheduled": "Scheduled topics cannot be (un)pinned.",
-  	"cant-merge-scheduled": "Scheduled topics cannot be merged.",
-  	"cant-move-posts-to-scheduled": "Can't move posts to a scheduled topic.",
-  	"cant-move-from-scheduled-to-existing": "Can't move posts from a scheduled topic to an existing topic.",
-
+	"scheduling-to-past": "Please select a date in the future.",
+	"invalid-schedule-date": "Please enter a valid date and time.",
+	"cant-pin-scheduled": "Scheduled topics cannot be (un)pinned.",
+	"cant-merge-scheduled": "Scheduled topics cannot be merged.",
+	"cant-move-posts-to-scheduled": "Can't move posts to a scheduled topic.",
+	"cant-move-from-scheduled-to-existing": "Can't move posts from a scheduled topic to an existing topic.",
 	"already-bookmarked": "You have already bookmarked this post",
 	"already-unbookmarked": "You have already unbookmarked this post",
-
 	"cant-ban-other-admins": "You can't ban other admins!",
 	"cant-mute-other-admins": "You can't mute other admins!",
 	"user-muted-for-hours": "You have been muted, you will be able to post in %1 hour(s)",
@@ -133,15 +116,12 @@
 	"cant-remove-last-admin": "You are the only administrator. Add another user as an administrator before removing yourself as admin",
 	"account-deletion-disabled": "Account deletion is disabled",
 	"cant-delete-admin": "Remove administrator privileges from this account before attempting to delete it.",
-
 	"already-deleting": "Already deleting",
-
 	"invalid-image": "Invalid image",
 	"invalid-image-type": "Invalid image type. Allowed types are: %1",
 	"invalid-image-extension": "Invalid image extension",
 	"invalid-file-type": "Invalid file type. Allowed types are: %1",
 	"invalid-image-dimensions": "Image dimensions are too big",
-
 	"group-name-too-short": "Group name too short",
 	"group-name-too-long": "Group name too long",
 	"group-already-exists": "Group already exists",
@@ -153,22 +133,16 @@
 	"group-already-requested": "Your membership request has already been submitted",
 	"group-join-disabled": "You are not able to join this group at this time",
 	"group-leave-disabled": "You are not able to leave this group at this time",
-
 	"post-already-deleted": "This post has already been deleted",
 	"post-already-restored": "This post has already been restored",
-
 	"topic-already-deleted": "This topic has already been deleted",
 	"topic-already-restored": "This topic has already been restored",
-
 	"cant-purge-main-post": "You can't purge the main post, please delete the topic instead",
-
 	"topic-thumbnails-are-disabled": "Topic thumbnails are disabled.",
 	"invalid-file": "Invalid File",
 	"uploads-are-disabled": "Uploads are disabled",
-
-	"signature-too-long" : "Sorry, your signature cannot be longer than %1 character(s).",
-	"about-me-too-long" : "Sorry, your about me cannot be longer than %1 character(s).",
-
+	"signature-too-long": "Sorry, your signature cannot be longer than %1 character(s).",
+	"about-me-too-long": "Sorry, your about me cannot be longer than %1 character(s).",
 	"cant-chat-with-yourself": "You can't chat with yourself!",
 	"chat-restricted": "This user has restricted their chat messages. They must follow you before you can chat with them",
 	"chat-disabled": "Chat system disabled",
@@ -182,7 +156,6 @@
 	"chat-deleted-already": "This chat message has already been deleted.",
 	"chat-restored-already": "This chat message has already been restored.",
 	"chat-room-does-not-exist": "Chat room does not exist.",
-
 	"already-voting-for-this-post": "You have already voted for this post.",
 	"reputation-system-disabled": "Reputation system is disabled.",
 	"downvoting-disabled": "Downvoting is disabled",
@@ -205,34 +178,26 @@
 	"too-many-upvotes-today-user": "You can only upvote a user %1 times a day",
 	"too-many-downvotes-today": "You can only downvote %1 times a day",
 	"too-many-downvotes-today-user": "You can only downvote a user %1 times a day",
-
 	"reload-failed": "NodeBB encountered a problem while reloading: \"%1\". NodeBB will continue to serve the existing client-side assets, although you should undo what you did just prior to reloading.",
-
 	"registration-error": "Registration Error",
 	"parse-error": "Something went wrong while parsing server response",
 	"wrong-login-type-email": "Please use your email to login",
 	"wrong-login-type-username": "Please use your username to login",
 	"sso-registration-disabled": "Registration has been disabled for %1 accounts, please register with an email address first",
 	"sso-multiple-association": "You cannot associate multiple accounts from this service to your NodeBB account. Please dissociate your existing account and try again.",
-
 	"invite-maximum-met": "You have invited the maximum amount of people (%1 out of %2).",
-
 	"no-session-found": "No login session found!",
 	"not-in-room": "User not in room",
 	"cant-kick-self": "You can't kick yourself from the group",
 	"no-users-selected": "No user(s) selected",
 	"invalid-home-page-route": "Invalid home page route",
-
 	"invalid-session": "Invalid Session",
 	"invalid-session-text": "It looks like your login session is no longer active. Please refresh this page.",
-
 	"session-mismatch": "Session Mismatch",
 	"session-mismatch-text": "It looks like your login session no longer matches with the server. Please refresh this page.",
-
 	"no-topics-selected": "No topics selected!",
 	"cant-move-to-same-topic": "Can't move post to same topic!",
 	"cant-move-topic-to-same-category": "Can't move topic to the same category!",
-
 	"cannot-block-self": "You cannot block yourself!",
 	"cannot-block-privileged": "You cannot block administrators or global moderators",
 	"cannot-block-guest": "Guest are not able to block other users",
@@ -240,16 +205,12 @@
 	"already-unblocked": "This user is already unblocked",
 	"no-connection": "There seems to be a problem with your internet connection",
 	"socket-reconnect-failed": "Unable to reach the server at this time. Click here to try again, or try again later",
-
 	"plugin-not-whitelisted": "Unable to install plugin &ndash; only plugins whitelisted by the NodeBB Package Manager can be installed via the ACP",
 	"plugins-set-in-configuration": "You are not allowed to change plugin state as they are defined at runtime (config.json, environmental variables or terminal arguments), please modify the configuration instead.",
 	"theme-not-set-in-configuration": "When defining active plugins in configuration, changing themes requires adding the new theme to the list of active plugins before updating it in the ACP",
-
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",
-
 	"cant-set-child-as-parent": "Can't set child as parent category",
 	"cant-set-self-as-parent": "Can't set self as parent category",
-
 	"api.master-token-no-uid": "A master token was received without a corresponding `_uid` in the request body",
 	"api.400": "Something was wrong with the request payload you passed in.",
 	"api.401": "A valid login session was not found. Please log in and try again.",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/en-x-pirate/error.json
+++ b/public/language/en-x-pirate/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/sc/error.json
+++ b/public/language/sc/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken, ${username}]]`);
                 }
 
                 callback();


### PR DESCRIPTION
Related Issue:
Resolves #1 [Suggest a new username if a username is taken during registration ](https://github.com/CMU-313/NodeBB-F25-R3/issues/1)

Changes Made:
- Updated English error.json files (files: en-GB, en-US, en-x-pirate, sc) with new error message: "Username taken. Maybe try "\<input\>suffix""
- Modified validateUsername function in public/src/client/register.js to pass in username variable to error message

Testing:
New error message displayed in local server.
<img width="1429" height="831" alt="Screenshot 2025-09-15 at 3 39 00 PM" src="https://github.com/user-attachments/assets/792a7287-0ee8-411a-9a47-710f89e45aeb" />
