### PR TITLE
Added the username suggestion should the username be taken during registration.

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try @<span id='yourUsername'>username</span>suffix",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",


### PR DESCRIPTION
Issue: https://github.com/CMU-313/NodeBB-F25-R3/issues/1

Changes: Included "@<span id='yourUsername'>username</span>suffix"," to line 34 of the public/language/en-US/error.json file

Applies: Username provided during registration.

Testing: Verified through registration in the local host server.