### PR TITLE
suggest alternative username when chosen one is taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,13 +131,27 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    // --- NEW: suggest an alternative username ---
+                    const suggestion = username + 'suffix';
+                    translator.translate('[[error:username-taken]]', function (msg) {
+                        username_notify.html(
+                            msg + ' ' +
+                            'Try this instead: ' +
+                            `<strong>${suggestion}</strong>`
+                        );
+                        username_notify.parent()
+                            .removeClass('register-success')
+                            .addClass('register-danger');
+                        username_notify.show();
+                    });
+                    validationError = true;
                 }
 
                 callback();
             });
         }
     }
+
 
     function validatePassword(password, password_confirm) {
         const password_notify = $('#password-notify');


### PR DESCRIPTION
**Context**

The registration logic responsible for validating usernames is implemented on the client side. To make the change, I located the validateUsername function inside public/src/client/register.js. Since the "username taken" message originates from validateUsername, this was the correct place to modify the behavior to also suggest an alternative username.

**Description**

This pull request updates the registration form logic in public/src/client/register.js to improve the user experience when a chosen username is already in use.

Previously, the UI only displayed an error message ("Username taken"). Now, if the entered username is taken, the form will also display a suggested alternative username by appending a "suffix" string to the original input (e.g., test123 → test123suffix).

**Changes include:**

Modified validateUsername():

When API checks detect the username is taken, display an error message with a suggested alternative username

Preserves existing success/error logic

**Testing:**

Enter a username that is known to be taken

Confirm that the error message displays along with a suggested alternative username

Enter a new, unused username to confirm normal registration behavior is unaffected