### PR TITLE
feature: suggest new username when username has been taken

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -112,6 +112,7 @@ define('forum/register', [
     };
 
     function validateUsername(username, callback) {
+        console.log('called validate username in register.js');
         callback = callback || function () {};
 
         const username_notify = $('#username-notify');
@@ -131,7 +132,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    console.log('register.js');
+                    showError(username_notify, `[[error:username-taken, "${username}suffix"]]`);
                 }
 
                 callback();


### PR DESCRIPTION
Related Issue:
Resolves #1 

Changes Made:
Modified public/src/client/registration.js to display a suggested name along with the existing error message when the inputted username is already taken. The suggested username will be the provided one with the suffix 'suffix'.

Applies to:
Username provided during registration

Testing:
Verified updated message displays during registration in local server
<img width="1252" height="593" alt="image" src="https://github.com/user-attachments/assets/6b1f9209-2ef3-4e52-9772-3ba1975d535d" />


