### PR TITLE
Added to the error message for when username is already taken from registration.

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]: try adding a 0 or a 1 to your username');
                 }
 
                 callback();


### PR DESCRIPTION
I found the area of code that I should edit, but I'm not sure how to get the username specifically to be displayed. I found that adding to the string will have it displayed when the username is taken, but not sure how to change the string so I just had it suggest adding a 0 or a 1 when a username is already taken. 

The location that I changed was public/src/client/register.js:134.