### PR TITLE
Add username suggestion when taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -1,3 +1,4 @@
+// Edited by Cursor AI: Suggest a username with a numeric suffix if taken (English-only UI).
 'use strict';
 
 
@@ -131,7 +132,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suggestion = username + '1';
+                    showError(username_notify, 'This username is taken. Try "' + suggestion + '"');
                 }
 
                 callback();


### PR DESCRIPTION
Generated by cursor:
     Implements feature request for username suggestions when username is taken.
     
     **Changes:**
     - Modified `public/src/client/register.js` to suggest username + '1' when original username is taken
     - Shows English-only message "This username is taken. Try '[username]1'" instead of i18n error
     - Follows prompt requirements for English-only implementation
     
     **Testing:**
     - Try registering with an existing username
     - Should now see suggestion instead of generic error message