### PR TITLE
feat(register.js): add username suggestion when taken (lines 134–135 in public/src/client/register.js)

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -132,7 +132,7 @@ define('forum/register', [
                     showSuccess(username_notify, successIcon);
                 } else {
                     const suggestion = `${userslug}suffix`;   // sanitized slug + suffix
-                    showError(username_notify, `[[error:username-taken]] Maybe try "${suggestion}".`);
+                    showError(username_notify, `[[error:username-taken]] maybe try "${suggestion}".`);
                 }
 
                 callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,8 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    const suggestion = utils.generateUsernameSuggestion(username);
-                    showError(username_notify, '[[error:username-taken-suggestion, ' + suggestion + ']]');
+                    const suggestion = `${userslug}suffix`;   // sanitized slug + suffix
+                    showError(username_notify, `[[error:username-taken]] Maybe try "${suggestion}".`);
                 }
 
                 callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suggestion = utils.generateUsernameSuggestion(username);
+                    showError(username_notify, '[[error:username-taken-suggestion, ' + suggestion + ']]');
                 }
 
                 callback();


### PR DESCRIPTION
Linked Issue:
https://github.com/CMU-313/NodeBB-F25-R3/issues/1

Added a simple suggestion when a chosen username is taken, by appending "suffix".

- File: `public/src/client/register.js`  
- Lines: 134–135

After: 
<img width="1220" height="624" alt="Screenshot 2025-09-15 at 5 19 50 PM" src="https://github.com/user-attachments/assets/3f4b9571-38ee-4a64-adac-cf64bd507aa5" />




